### PR TITLE
Fix typo in graphql_check

### DIFF
--- a/src/graphql_check.erl
+++ b/src/graphql_check.erl
@@ -395,7 +395,7 @@ check_value(Ctx, Val, #enum_type{} = Sigma) ->
 check_value(Ctx, Val, Sigma) ->
     err(Ctx, {type_mismatch,
               #{ document => Val,
-                 schmema => Sigma }}).
+                 schema => Sigma }}).
 
 check_input_obj(Ctx, {input_object, Obj},
                 #input_object_type{ fields = Fields }) ->


### PR DESCRIPTION
Because of this typo, checking an empty array against the defined type results in the following exception:
```
{'EXIT',
 {function_clause,
  [{graphql_err,
    type_check_err_msg,
```

After the fix, it returns the standard error with the following message: `Type mismatch. The query document has a value/variable of type ([]) but the schema expects type (...)`. 