### PR TITLE
Enable unknown types warnings

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -31,3 +31,5 @@
   {geas_rebar3, {git, "https://github.com/crownedgrouse/geas_rebar3.git", {branch, "master"}}},
   rebar3_hex
 ]}.
+
+{dialyzer, [{warnings, [unknown]}]}.

--- a/src/graphql.erl
+++ b/src/graphql.erl
@@ -55,12 +55,15 @@
 -type defer_map() :: #{ worker => pid(),
                         timeout => non_neg_integer(),
                         apply => [fun()]}.
+-type ast() :: document().
 -type result() :: {ok, term()} | {error, term()} | {defer, token()} | {defer, token(), defer_map()}.
 -type name() :: {name, pos_integer(), binary()} | binary().
 -type document() :: #document{}.
 -type directive() :: #directive{}.
--export_type([directive/0,
 
+-export_type([ast/0,
+              directive/0,
+              name/0,
               token/0,
               schema_field/0]).
 

--- a/src/graphql_check.erl
+++ b/src/graphql_check.erl
@@ -57,6 +57,8 @@
 -export([check/2, check_params/4]).
 -export([funenv/2]).
 
+-export_type([ty/0]).
+
 -record(ctx,
         {
          endpoint_ctx :: endpoint_context(),
@@ -513,6 +515,7 @@ check_sset_(Ctx, [#field{ args = Args, directives = Dirs,
 %%
 %% We derive an expression in which we have annotated types into
 %% the AST. This helps the later execution stage.
+-spec check(term(), term(), undefined | graphql_base_type() | ty()) -> term().
 check(Ctx, #frag { ty = undefined } = Frag, Sigma) ->
     %% The specification has a rule in which if you omit the
     %% type of a fragment, it "picks up" the type of the context

--- a/src/graphql_check.erl
+++ b/src/graphql_check.erl
@@ -515,7 +515,7 @@ check_sset_(Ctx, [#field{ args = Args, directives = Dirs,
 %%
 %% We derive an expression in which we have annotated types into
 %% the AST. This helps the later execution stage.
--spec check(term(), term(), undefined | graphql_base_type() | ty()) -> term().
+-spec check(term(), term(), undefined | graphql_base_type() | ty()) -> {ok, #frag{} | #op{}}.
 check(Ctx, #frag { ty = undefined } = Frag, Sigma) ->
     %% The specification has a rule in which if you omit the
     %% type of a fragment, it "picks up" the type of the context

--- a/src/graphql_internal.hrl
+++ b/src/graphql_internal.hrl
@@ -40,7 +40,7 @@
 
 -record(frag,
         { id :: '...' | graphql:name(), %% One variant is for inline fragments
-          ty :: undefined | graphql_base_type(),
+          ty :: undefined | graphql_base_type() | graphql_check:ty(),
           directives = [] :: [graphql:directive()],
           selection_set = [] :: [#field{}],
           schema = undefined :: 'undefined' | any()


### PR DESCRIPTION
Enable unknown types warnings

Also fixes:

```erlang
src/graphql_check.erl
Line 466 Column 30: The call graphql_check:check(Ctx::#ctx{endpoint_ctx::#endpoint_context{name::atom(),pid::pid(),enums_tab::atom(),objects_tab::atom()},path::[any(),...],vars::#{binary()=>{_,_,_,_}},frags::#{binary()=>{_,_,_,_,_,_}},sub_context::'query' | 'variable'}, Frag::#frag{id::'...',directives::[#directive{id::binary() | {'name',pos_integer(),binary()},args::[{_,_}] | #{binary()=>_}}],selection_set::[#field{id::binary() | {'name',pos_integer(),binary()},args::[{binary(),#{'default':='null' | 'undefined' | binary() | {'enum',binary()} | {'list',_} | {'object',[any()]} | {'bool',boolean(),pos_integer()} | {'float',float(),pos_integer()} | {'int',integer(),pos_integer()} | {'name',pos_integer(),binary()} | {'string',binary(),pos_integer()}, 'type':=binary() | {'list',_} | {'non_null',_} | {'name',pos_integer(),binary()}, 'value':='null' | binary() | {'enum',binary()} | {'list',_} | {'object',[any()]} | {'bool',boolean(),pos_integer()} | {'float',float(),pos_integer()} | {'int',integer(),pos_integer()} | {'name',pos_integer(),binary()} | {'string',binary(),pos_integer()}}}],directives::[any()],selection_set::[any()],alias::'undefined' | binary() | {'name',pos_integer(),binary()}}]}, Sigma::binary() | {'list',binary() | {_,_,_,_,_} | {_,_,_,_,_,_}} | {'non_null',{'list',binary() | {_,_,_,_,_} | {_,_,_,_,_,_}} | #scalar_type{id::binary(),description::binary(),directives::[any()],resolve_module::atom()} | #enum_type{id::binary(),description::binary(),resolve_module::atom(),directives::[any()],values::map()}} | {_,_,_,_,_} | {_,_,_,_,_,_} | #object_type{id::binary(),description::binary(),directives::[{_,_,_,_}],resolve_module::atom(),fields::#{binary()=>{_,_,_,_,_,_,_}},interfaces::[binary()]}) will never return since it differs in the 2nd argument from the success typing arguments: (#ctx{endpoint_ctx::#endpoint_context{name::atom(),pid::pid(),enums_tab::atom(),objects_tab::atom()},path::[any()],vars::#{binary()=>{_,_,_,_}},frags::#{binary()=>{_,_,_,_,_,_}},sub_context::'query' | 'variable'}, #frag{id::'...' | binary() | {'name',pos_integer(),binary()},ty::binary(),directives::[{_,_,_,_}],selection_set::[{_,_,_,_,_,_,_}]} | #op{ty::'undefined' | {'mutation',pos_integer()} | {'query',pos_integer()} | {'subscription',pos_integer()},id::'ROOT' | binary() | {'name',pos_integer(),binary()},vardefs::[{_,_,_,_}],directives::[{_,_,_,_}],selection_set::[{_,_,_} | {_,_,_,_,_,_,_}]}, {'list',#interface_type{id::binary(),description::binary(),resolve_type::atom() | fun((_) -> any()),directives::[any()],fields::map()} | #union_type{id::binary(),description::binary(),resolve_type::atom() | fun((_) -> any()),directives::[any()],types::[any()]}} | {'non_null',{'list',{_,_,_,_,_,_}}} | #interface_type{id::binary(),description::binary(),resolve_type::atom() | fun((_) -> {_,_}),directives::[{_,_,_,_}],fields::#{binary()=>{_,_,_,_,_,_,_}}} | #union_type{id::binary(),description::binary(),resolve_type::atom() | fun((_) -> {_,_}),directives::[{_,_,_,_}],types::[binary() | {_,_,_}]} | #object_type{id::binary(),description::binary(),directives::[{_,_,_,_}],resolve_module::atom(),fields::#{binary()=>{_,_,_,_,_,_,_}},interfaces::[binary()]})
Line 522 Column 42: The call graphql_check:check(Ctx::#ctx{endpoint_ctx::#endpoint_context{name::atom(),pid::pid(),enums_tab::atom(),objects_tab::atom()},path::[any()],vars::#{binary()=>{_,_,_,_}},frags::#{binary()=>{_,_,_,_,_,_}},sub_context::'query' | 'variable'}, #frag{id::'...' | binary() | {'name',pos_integer(),binary()},ty::binary(),directives::[#directive{id::binary() | {'name',pos_integer(),binary()},args::[{_,_}] | #{binary()=>_}}],selection_set::[#field{id::binary() | {'name',pos_integer(),binary()},args::[{binary(),#{'default':='null' | 'undefined' | binary() | {'enum',binary()} | {'list',_} | {'object',[any()]} | {'bool',boolean(),pos_integer()} | {'float',float(),pos_integer()} | {'int',integer(),pos_integer()} | {'name',pos_integer(),binary()} | {'string',binary(),pos_integer()}, 'type':=binary() | {'list',_} | {'non_null',_} | {'name',pos_integer(),binary()}, 'value':='null' | binary() | {'enum',binary()} | {'list',_} | {'object',[any()]} | {'bool',boolean(),pos_integer()} | {'float',float(),pos_integer()} | {'int',integer(),pos_integer()} | {'name',pos_integer(),binary()} | {'string',binary(),pos_integer()}}}],directives::[any()],selection_set::[any()],alias::'undefined' | binary() | {'name',pos_integer(),binary()}}]}, Sigma::binary()) will never return since it differs in the 3rd argument from the success typing arguments: (#ctx{endpoint_ctx::#endpoint_context{name::atom(),pid::pid(),enums_tab::atom(),objects_tab::atom()},path::[any()],vars::#{binary()=>{_,_,_,_}},frags::#{binary()=>{_,_,_,_,_,_}},sub_context::'query' | 'variable'}, #frag{id::'...' | binary() | {'name',pos_integer(),binary()},ty::binary(),directives::[{_,_,_,_}],selection_set::[{_,_,_,_,_,_,_}]} | #op{ty::'undefined' | {'mutation',pos_integer()} | {'query',pos_integer()} | {'subscription',pos_integer()},id::'ROOT' | binary() | {'name',pos_integer(),binary()},vardefs::[{_,_,_,_}],directives::[{_,_,_,_}],selection_set::[{_,_,_} | {_,_,_,_,_,_,_}]}, {'list',#interface_type{id::binary(),description::binary(),resolve_type::atom() | fun((_) -> any()),directives::[any()],fields::map()} | #union_type{id::binary(),description::binary(),resolve_type::atom() | fun((_) -> any()),directives::[any()],types::[any()]}} | {'non_null',{'list',{_,_,_,_,_,_}}} | #interface_type{id::binary(),description::binary(),resolve_type::atom() | fun((_) -> {_,_}),directives::[{_,_,_,_}],fields::#{binary()=>{_,_,_,_,_,_,_}}} | #union_type{id::binary(),description::binary(),resolve_type::atom() | fun((_) -> {_,_}),directives::[{_,_,_,_}],types::[binary() | {_,_,_}]} | #object_type{id::binary(),description::binary(),directives::[{_,_,_,_}],resolve_module::atom(),fields::#{binary()=>{_,_,_,_,_,_,_}},interfaces::[binary()]})
```