### PR TITLE
Make geas a project plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -28,8 +28,11 @@
 ]}.
 
 {plugins, [
-  {geas_rebar3, {git, "https://github.com/crownedgrouse/geas_rebar3.git", {branch, "master"}}},
   rebar3_hex
+]}.
+
+{project_plugins, [
+  {geas_rebar3, {git, "https://github.com/crownedgrouse/geas_rebar3.git", {branch, "master"}}}
 ]}.
 
 {dialyzer, [{warnings, [unknown]}]}.


### PR DESCRIPTION
Make geas a project plugin.
So projects that use graphql as a dependency do not pull the plugin.